### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+asyn (4.33-3) unstable; urgency=medium
+
+  [ Michael Davidsaver ]
+  * add missing jquery.js
+
+  [ Martin Konrad ]
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Thu, 13 Sep 2018 13:11:46 -0400
+
 asyn (4.33-2) unstable; urgency=medium
 
   * Add patch that fixes uninitialized variable

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: asyn
 Section: libdevel
 Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@gmail.com>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.12~),
-               epics-dev (>= 3.14.12),
-               rtems-epics-mvme2100,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
-               rtems-epics-pc386,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.12~), epics-dev (>= 3.14.12),
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
+               rtems-epics-pc386 <pkg.epics-base.rtems>,
                libusb-1.0-0-dev,
 XS-Rtems-Build-Depends: rtems-epics
 Standards-Version: 3.9.6
@@ -43,6 +43,7 @@ Description: Facility for interfacing to low level communication drivers
  This package contains runtime libraries
 
 Package: rtems-asyn-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-asyn-dev (>= ${source:Version}),
          epics-asyn-dev (<< ${source:Version}.1~),
@@ -58,6 +59,7 @@ Description: Facility for interfacing to low level communication drivers
  This package contains support for the MVME2100 VME SBC
 
 Package: rtems-asyn-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-asyn-dev (>= ${source:Version}),
          epics-asyn-dev (<< ${source:Version}.1~),
@@ -73,6 +75,7 @@ Description: Facility for interfacing to low level communication drivers
  This package contains support for the MVME3100 VME SBC
 
 Package: rtems-asyn-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-asyn-dev (>= ${source:Version}),
          epics-asyn-dev (<< ${source:Version}.1~),
@@ -88,6 +91,7 @@ Description: Facility for interfacing to low level communication drivers
  This package contains support for the MVME5500 VME SBC
 
 Package: rtems-asyn-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-asyn-dev (>= ${source:Version}),
          epics-asyn-dev (<< ${source:Version}.1~),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,8 @@
+asyn source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-asyn-mvme2100
+asyn source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-asyn-mvme3100
+asyn source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-asyn-mvme5500
+asyn source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-asyn-pc386
+asyn source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+asyn source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+asyn source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]
+asyn source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.asyn.rtems` when compiling to enable the RTEMS build.